### PR TITLE
Fix: ansible-galaxy minus to underscore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - ansible --version
 
   # Link github repo to ansible-galaxy name
-  - ln -s  $PWD ../while-true-do.repo-epel
+  - ln -s  $PWD ../while_true_do.repo-epel
 
 # Run the tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - ansible --version
 
   # Link github repo to ansible-galaxy name
-  - ln -s  $PWD ../while_true_do.repo-epel
+  - ln -s  $PWD ../while_true_do.repo_epel
 
 # Run the tests
 script:

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ This role is needed to get access for Extra Packages for Enterprise Linux (EPEL)
 
 ## Installation
 
-Install from [Ansible Galaxy](https://galaxy.ansible.com/while_true_do.repo-epel)
+Install from [Ansible Galaxy](https://galaxy.ansible.com/while_true_do.repo_epel)
 
 ```
-ansible-galaxy install while_true_do.repo-epel
+ansible-galaxy install while_true_do.repo_epel
 ```
 
 Install from [Github](https://github.com/while-true-do/ansible-role-repo-epel)
@@ -46,7 +46,7 @@ Simple Example:
 ```yaml
 - hosts: servers 
   roles:
-    - { role: while_true_do.repo-epel }
+    - { role: while_true_do.repo_epel }
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ This role is needed to get access for Extra Packages for Enterprise Linux (EPEL)
 
 ## Installation
 
-Install from [Ansible Galaxy](https://galaxy.ansible.com/while-true-do.repo-epel)
+Install from [Ansible Galaxy](https://galaxy.ansible.com/while_true_do.repo-epel)
 
 ```
-ansible-galaxy install while-true-do.repo-epel
+ansible-galaxy install while_true_do.repo-epel
 ```
 
 Install from [Github](https://github.com/while-true-do/ansible-role-repo-epel)
 
 ```
-git clone https://github.com/while-true-do/ansible-role-repo-epel.git while-true-do.repo-epel
+git clone https://github.com/while-true-do/ansible-role-repo-epel.git while_true_do.repo-epel
 ```
 
 ## Requirements
@@ -46,7 +46,7 @@ Simple Example:
 ```yaml
 - hosts: servers 
   roles:
-    - { role: while-true-do.repo-epel }
+    - { role: while_true_do.repo-epel }
 ```
 
 ## Testing

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,11 +1,12 @@
 dependencies: []
 
 galaxy_info:
+  role_name: repo_epel
   author: while-true-do.org
   description: A role that installs yum repository for Extra Packages for Enterprise Linux (EPEL).
   company: while-true-do.org
 
-    github_branch: master
+  github_branch: master
   license: BSD
 
   min_ansible_version: 2.0

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,8 +5,7 @@ galaxy_info:
   description: A role that installs yum repository for Extra Packages for Enterprise Linux (EPEL).
   company: while-true-do.org
 
-  issue_tracker_url: https://github.com/while-true-do/ansible-role-repo-epel/issues
-  github_branch: master
+    github_branch: master
   license: BSD
 
   min_ansible_version: 2.0

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - while_true_do.repo-epel
+    - while_true_do.repo_epel

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - while-true-do.repo-epel
+    - while_true_do.repo-epel


### PR DESCRIPTION
# Fix: ansible-galaxy minus to underscore

Ansible Galaxy decided to change "-" to "_" and there
is no way currently to roll this back.
So change the role names and galaxy links to "while_true_do"

## Reference

 - Resolves:
